### PR TITLE
Use verified Hebrew epoch and fix calendar calculations

### DIFF
--- a/source/HebrewCalendarTest.mc
+++ b/source/HebrewCalendarTest.mc
@@ -16,6 +16,6 @@ class HebrewCalendarTest {
         var formatted = HebrewCalendar.formatHebrewDate(hebrewDate);
         System.println("Formatted: " + formatted);
         
-        // Expected: 23 Av 5785 (Hebrew year month 12, standard month 5)
+        // Expected: 23 Av 5785 (Hebrew year month 11, standard month 5)
     }
 }


### PR DESCRIPTION
## Summary
- adopt standard Hebrew epoch constant and remove ad-hoc offset
- implement accurate elapsed-day and month-length calculations for Hebrew calendar
- adjust test expectation for Av 5785 sample date

## Testing
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a47917ff18832bb8234f29e8b87a5c