### PR TITLE
Fix Hebrew date calculation based on daily sunset

### DIFF
--- a/source/JF-HebrewCalendarView.mc
+++ b/source/JF-HebrewCalendarView.mc
@@ -307,9 +307,9 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
         iconStr = "0>";
         nextLabel = Lang.format("   $1$:$2$", [sunRiseTime.hour.format("%02d"), sunRiseTime.min.format("%02d")]);
         }
-      var lastSunset = sunset.subtract(new Time.Duration(86400));
-      hDate = HebrewCalendar.getFormattedHebrewDateInHebrew(lastSunset);
-      holyday = HebrewCalendar.getHebrewHolyday(lastSunset);
+      var todaySunset = sunCalc.calculate(now, lat, lon, SUNSET);
+      hDate = HebrewCalendar.getFormattedHebrewDateInHebrew(todaySunset);
+      holyday = HebrewCalendar.getHebrewHolyday(todaySunset);
     } else {
       hDate = HebrewCalendar.getFormattedHebrewDateThisMorningInHebrew();
       holyday = HebrewCalendar.getHebrewHolydayForThisMorning();


### PR DESCRIPTION
## Summary
- use today's sunset time to determine current Hebrew date and holiday

## Testing
- `monkeyc --version` *(fails: command not found)*
- `apt-get install -y monkeyc` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b7264730fc832b89c81aa6920141a9