### PR TITLE
Add chag detection for work-prohibited holidays

### DIFF
--- a/source/HebrewCalendar.mc
+++ b/source/HebrewCalendar.mc
@@ -567,6 +567,59 @@ class HebrewCalendar {
     return "";
   }
 
+  // Returns true if the given Hebrew date is a chag on which melacha is prohibited
+  static function isChagForDate(hd) as Boolean {
+    var year = hd[0];
+    var month = hd[1];
+    var day = hd[2];
+    var isLeap = isHebrewLeapYear(year);
+    var standardMonth = hebrewYearMonthToStandardMonth(month, isLeap);
+
+    if (standardMonth == 7) {
+      // Tishrei: Rosh Hashana (1-2), Yom Kippur (10), Sukkot (15), Shemini Atzeret (22)
+      if (day == 1 || day == 2 || day == 10 || day == 15 || day == 22) {
+        return true;
+      }
+    } else if (standardMonth == 1) {
+      // Nisan: Pesach (15), Last day of Pesach (21)
+      if (day == 15 || day == 21) {
+        return true;
+      }
+    } else if (standardMonth == 3) {
+      // Sivan: Shavuot (6)
+      if (day == 6) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  // Returns true if today (this morning) is a chag on which melacha is prohibited
+  static function isChagForThisMorning() as Boolean {
+    var hd = getHebrewDateThisMorning();
+    return isChagForDate(hd);
+  }
+
+  // Returns true if tomorrow morning is a chag on which melacha is prohibited
+  static function isChagForTomorrowMorning() as Boolean {
+    var gd = Gregorian.info(Time.now(), Time.FORMAT_SHORT);
+    var abs =
+      gregorianToAbsolute(
+        toLongSafe(gd.year),
+        toLongSafe(gd.month),
+        toLongSafe(gd.day)
+      ) + 1;
+    var hd = absoluteToHebrew(abs);
+    return isChagForDate(hd);
+  }
+
+  // Returns true if given sunset-adjusted time falls on a chag on which melacha is prohibited
+  static function isChag(sunset) as Boolean {
+    var hd = getHebrewDateConsideringSunset(sunset);
+    return isChagForDate(hd);
+  }
+
   static function getHebrewHolydayForThisMorning() as String {
     var hd = getHebrewDateThisMorning();
     return getHebrewHolydayForDate(hd);

--- a/source/HebrewCalendarTest.mc
+++ b/source/HebrewCalendarTest.mc
@@ -18,4 +18,16 @@ class HebrewCalendarTest {
         
         // Expected: 23 Av 5785 (Hebrew year month 11, standard month 5)
     }
+
+    static function testIsChag() as Void {
+        // 16 September 2023 - Rosh Hashana (1 Tishrei 5784)
+        var absRh = HebrewCalendar.gregorianToAbsolute(2023, 9, 16);
+        var hdRh = HebrewCalendar.absoluteToHebrew(absRh);
+        System.println("Rosh Hashana 5784 day 1 is chag: " + HebrewCalendar.isChagForDate(hdRh));
+
+        // 18 September 2023 - 3 Tishrei 5784 (no chag)
+        var absChol = HebrewCalendar.gregorianToAbsolute(2023, 9, 18);
+        var hdChol = HebrewCalendar.absoluteToHebrew(absChol);
+        System.println("18 Sep 2023 is chag: " + HebrewCalendar.isChagForDate(hdChol));
+    }
 }


### PR DESCRIPTION
## Summary
- expose functions to identify melacha-prohibited chag days
- add tests demonstrating chag detection

## Testing
- `monkeyc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d6391138832b9e76ad8f1364aed0