### PR TITLE
Avoid storage reads during partial updates

### DIFF
--- a/source/JF-HebrewCalendarView.mc
+++ b/source/JF-HebrewCalendarView.mc
@@ -147,9 +147,6 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     xScale = width / 260.0;
     yScale = height / 260.0;
     hasOldApi = resolutionToOldApi(width, height);
-    if (!hasOldApi) {
-      restoreStoredLocation();
-    }
   }
 
   function resolutionToOldApi(width, height) {
@@ -178,6 +175,9 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     setLayout(Rez.Layouts.WatchFace(dc));
     cacheDrawables();
     computeScale(dc);
+    if (!hasOldApi) {
+      restoreStoredLocation();
+    }
     loadResources();
     positionLabels();
   }


### PR DESCRIPTION
## Summary
- Move `restoreStoredLocation` out of `computeScale` to prevent expensive storage reads on each partial update tick.
- Restore stored location once during layout so scaling information is still computed correctly.

## Testing
- `monkeyc -o /tmp/app.prg -m manifest.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08231e8e0832b90c7bd8bcface4ed