### PR TITLE
Add configurable time format

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -1,7 +1,8 @@
 <properties>
     <property id="showBattery" type="boolean">true</property>
     <property id="showTime" type="boolean">true</property>
-    <property id="timeColor" type="number">1</property> 
+    <property id="timeColor" type="number">1</property>
+    <property id="timeFormat" type="number">1</property>
     <property id="showSeconds" type="boolean">true</property>
     <property id="secondsColor" type="number">1</property>
     <property id="showGregorianDate" type="boolean">true</property>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -19,6 +19,15 @@
         </settingConfig>
     </setting>
 
+    <setting propertyKey="@Properties.timeFormat" title="Time Format">
+        <settingConfig type="list">
+            <listEntry value="1">@Strings.TimeFormat24</listEntry>
+            <listEntry value="2">@Strings.TimeFormat24NoZero</listEntry>
+            <listEntry value="3">@Strings.TimeFormat12</listEntry>
+            <listEntry value="4">@Strings.TimeFormat12NoZero</listEntry>
+        </settingConfig>
+    </setting>
+
     <setting propertyKey="@Properties.showSeconds" title="Show Seconds">
         <settingConfig type="boolean" />
     </setting>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -11,6 +11,10 @@
     <string id="ColorGreen">Green</string>
     <string id="ColorOrange">Orange</string>
     <string id="ColorYellow">Yellow</string>
-    
 
+
+    <string id="TimeFormat24">24h (00:00)</string>
+    <string id="TimeFormat24NoZero">24h (0:00)</string>
+    <string id="TimeFormat12">12h (12:00 AM)</string>
+    <string id="TimeFormat12NoZero">12h (1:00 AM)</string>
 </strings>

--- a/source/JF-HebrewCalendarView.mc
+++ b/source/JF-HebrewCalendarView.mc
@@ -50,6 +50,7 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
   var rabbenuTam = false;
   var hebrewDateColor = Graphics.COLOR_BLUE;
   var timeColor = Graphics.COLOR_WHITE;
+  var timeFormat = 1;
   var secondsColor = Graphics.COLOR_BLUE;
   var gregorianDateColor = Graphics.COLOR_WHITE;
   var sunEventColor = Graphics.COLOR_YELLOW;
@@ -86,6 +87,17 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     return val == null ? current : val;
   }
 
+  function loadNumberSetting(name, current) {
+    var val = null;
+    if (!hasOldApi) {
+      val = appProperties.getValue(name);
+    } else {
+      val = Application.getApp().getProperty(name);
+    }
+
+    return val == null ? current : val;
+  }
+
   function loadColorSetting(name) {
     //
     if (!hasOldApi) {
@@ -110,6 +122,7 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
 
     hebrewDateColor = loadColorSetting("hebrewDateColor");
     timeColor = loadColorSetting("timeColor");
+    timeFormat = loadNumberSetting("timeFormat", timeFormat);
     secondsColor = loadColorSetting("secondsColor");
     gregorianDateColor = loadColorSetting("gregorianDateColor");
     sunEventColor = loadColorSetting("sunEventColor");
@@ -248,12 +261,37 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     batteryLabel.setFont(iconFont);
   }
 
+  function formatHourMinute(hour, min) {
+    var hourStr = "";
+    var ampm = "";
+    if (timeFormat == 2) {
+      hourStr = hour.format("%d");
+      return Lang.format("$1$:$2$", [hourStr, min.format("%02d")]);
+    } else if (timeFormat == 3) {
+      var h12 = hour % 12;
+      if (h12 == 0) {
+        h12 = 12;
+      }
+      ampm = hour < 12 ? "AM" : "PM";
+      hourStr = h12.format("%02d");
+      return Lang.format("$1$:$2$ $3$", [hourStr, min.format("%02d"), ampm]);
+    } else if (timeFormat == 4) {
+      var h12 = hour % 12;
+      if (h12 == 0) {
+        h12 = 12;
+      }
+      ampm = hour < 12 ? "AM" : "PM";
+      hourStr = h12.format("%d");
+      return Lang.format("$1$:$2$ $3$", [hourStr, min.format("%02d"), ampm]);
+    }
+
+    hourStr = hour.format("%02d");
+    return Lang.format("$1$:$2$", [hourStr, min.format("%02d")]);
+  }
+
   function updateTime(clockTime) {
     if (showTime) {
-      var timeStr = Lang.format("$1$:$2$", [
-        clockTime.hour.format("%02d"),
-        clockTime.min.format("%02d"),
-      ]);
+      var timeStr = formatHourMinute(clockTime.hour, clockTime.min);
       timeLabel.setColor(timeColor);
       timeLabel.setText(timeStr);
     } else {
@@ -373,21 +411,18 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
 
       if (beforeSunrise) {
         iconStr += ">";
-        nextLabel = Lang.format("   $1$:$2$", [
-          sunRiseTime.hour.format("%02d"),
-          sunRiseTime.min.format("%02d"),
+        nextLabel = Lang.format("   $1$", [
+          formatHourMinute(sunRiseTime.hour, sunRiseTime.min),
         ]);
       } else if (beforeSunset) {
         iconStr += "?";
-        nextLabel = Lang.format("   $1$:$2$", [
-          sunSetTime.hour.format("%02d"),
-          sunSetTime.min.format("%02d"),
+        nextLabel = Lang.format("   $1$", [
+          formatHourMinute(sunSetTime.hour, sunSetTime.min),
         ]);
       } else {
         iconStr += ">";
-        nextLabel = Lang.format("   $1$:$2$", [
-          sunRiseTime.hour.format("%02d"),
-          sunRiseTime.min.format("%02d"),
+        nextLabel = Lang.format("   $1$", [
+          formatHourMinute(sunRiseTime.hour, sunRiseTime.min),
         ]);
       }
       var todaySunset = sunCalc.calculate(now, lat, lon, SUNSET);


### PR DESCRIPTION
## Summary
- add Time Format setting with 24h and 12h options
- implement time formatting logic supporting leading-zero and am/pm variants

## Testing
- `monkeyc -d fenix6 -o /tmp/app.prg -f monkey.jungle` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e9933fa8832b8539129e84f46f63