### PR TITLE
feat: add configurable time fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Access the watch face settings through:
 - **Show Battery Level**: Toggle battery indicator
 - **Show Time**: Toggle time display
 - **Time Color**: Choose from 7 color options
+- **Time Font**: Select Number Medium, Number Hot, or Number Thai Hot fonts
 - **Show Seconds**: Toggle seconds display
 - **Seconds Color**: Choose from 7 color options
 - **Hebrew Date Color**: Choose from 7 color options

--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -1,7 +1,8 @@
 <properties>
     <property id="showBattery" type="boolean">true</property>
     <property id="showTime" type="boolean">true</property>
-    <property id="timeColor" type="number">1</property> 
+    <property id="timeColor" type="number">1</property>
+    <property id="timeFont" type="number">3</property>
     <property id="showSeconds" type="boolean">true</property>
     <property id="secondsColor" type="number">1</property>
     <property id="showGregorianDate" type="boolean">true</property>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -19,6 +19,14 @@
         </settingConfig>
     </setting>
 
+    <setting propertyKey="@Properties.timeFont" title="Time Font">
+        <settingConfig type="list">
+            <listEntry value="1">@Strings.FontNumberMedium</listEntry>
+            <listEntry value="2">@Strings.FontNumberHot</listEntry>
+            <listEntry value="3">@Strings.FontNumberThaiHot</listEntry>
+        </settingConfig>
+    </setting>
+
     <setting propertyKey="@Properties.showSeconds" title="Show Seconds">
         <settingConfig type="boolean" />
     </setting>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -11,6 +11,10 @@
     <string id="ColorGreen">Green</string>
     <string id="ColorOrange">Orange</string>
     <string id="ColorYellow">Yellow</string>
-    
+
+    <string id="FontNumberMedium">Number Medium</string>
+    <string id="FontNumberHot">Number Hot</string>
+    <string id="FontNumberThaiHot">Number Thai Hot</string>
+
 
 </strings>

--- a/source/JF-HebrewCalendarView.mc
+++ b/source/JF-HebrewCalendarView.mc
@@ -50,6 +50,7 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
   var rabbenuTam = false;
   var hebrewDateColor = Graphics.COLOR_BLUE;
   var timeColor = Graphics.COLOR_WHITE;
+  var timeFont = Graphics.FONT_NUMBER_THAI_HOT;
   var secondsColor = Graphics.COLOR_BLUE;
   var gregorianDateColor = Graphics.COLOR_WHITE;
   var sunEventColor = Graphics.COLOR_YELLOW;
@@ -95,6 +96,16 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     }
   }
 
+  function loadFontSetting(name) {
+    var font = null;
+    if (!hasOldApi) {
+      font = appProperties.getValue(name);
+    } else {
+      font = Application.getApp().getProperty(name);
+    }
+    return getFont(font);
+  }
+
   function loadSettings() {
     showBattery = loadBooleanSetting("showBattery", showBattery);
     showTime = loadBooleanSetting("showTime", showTime);
@@ -114,6 +125,10 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     gregorianDateColor = loadColorSetting("gregorianDateColor");
     sunEventColor = loadColorSetting("sunEventColor");
     stepsColor = loadColorSetting("stepsColor");
+    timeFont = loadFontSetting("timeFont");
+    if (timeLabel != null) {
+      timeLabel.setFont(timeFont);
+    }
   }
 
   // Resource loading and layout helpers
@@ -565,6 +580,21 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
   function onEnterSleep() as Void {}
 
   // Simplified color lookup
+  function getFont(font) {
+    var fonts = [
+      Graphics.FONT_NUMBER_MEDIUM,
+      Graphics.FONT_NUMBER_HOT,
+      Graphics.FONT_NUMBER_THAI_HOT,
+    ];
+    if (font == null) {
+      return Graphics.FONT_NUMBER_THAI_HOT;
+    }
+    if (font >= 1 && font <= fonts.size()) {
+      return fonts[font - 1];
+    }
+    return Graphics.FONT_NUMBER_THAI_HOT;
+  }
+
   function getColor(color) as ColorValue {
     var colors = [
       Graphics.COLOR_WHITE,


### PR DESCRIPTION
## Summary
- allow selecting different fonts for the time display
- document available font options

## Testing
- `monkeyc -o /tmp/out.prg -f monkey.jungle` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eb9f727c832b878dfbce23782ae9