### PR TITLE
Add configurable Gregorian date formats

### DIFF
--- a/resources/layouts/layout.xml
+++ b/resources/layouts/layout.xml
@@ -13,7 +13,7 @@
     <label id="SecondsLabel" x="195" y="118" font="Graphics.FONT_NUMBER_MILD" justification="Graphics.TEXT_JUSTIFY_LEFT" color="Graphics.COLOR_BLUE" />
 
     <!-- Gregorian date -->
-    <label id="bottomDateLabel" x="center" y="0" font="Graphics.FONT_LARGE" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_WHITE" />
+    <label id="bottomDateLabel" x="center" y="0" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_WHITE" />
 
     <!-- Steps and next sunrise/sunset -->
     <label id="iconsLabel" x="center" y="0" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_WHITE" />

--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -5,6 +5,7 @@
     <property id="showSeconds" type="boolean">true</property>
     <property id="secondsColor" type="number">1</property>
     <property id="showGregorianDate" type="boolean">true</property>
+    <property id="gregorianDateFormat" type="number">3</property>
     <property id="gregorianDateColor" type="number">1</property>
     <property id="showSunEvent" type="boolean">true</property>
     <property id="sunEventColor" type="number">1</property>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -51,6 +51,15 @@
         <settingConfig type="boolean" />
     </setting>
 
+    <setting propertyKey="@Properties.gregorianDateFormat" title="@Strings.GregorianDateFormatTitle">
+        <settingConfig type="list">
+            <listEntry value="1">@Strings.GregorianFormatDowDayMonth</listEntry>
+            <listEntry value="2">@Strings.GregorianFormatDowMonthDay</listEntry>
+            <listEntry value="3">@Strings.GregorianFormatDayMonthYear</listEntry>
+            <listEntry value="4">@Strings.GregorianFormatMonthDayYear</listEntry>
+        </settingConfig>
+    </setting>
+
     <setting propertyKey="@Properties.gregorianDateColor" title="Gregorian Date Color">
         <settingConfig type="list">
             <listEntry value="1">@Strings.ColorWhite</listEntry>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -11,6 +11,13 @@
     <string id="ColorGreen">Green</string>
     <string id="ColorOrange">Orange</string>
     <string id="ColorYellow">Yellow</string>
-    
+
+
+    <string id="GregorianDateFormatTitle">Gregorian Date Format</string>
+    <string id="GregorianFormatDowDayMonth">Weekday 17 Sep</string>
+    <string id="GregorianFormatDowMonthDay">Weekday Sep 17th</string>
+    <string id="GregorianFormatDayMonthYear">17/9/2025</string>
+    <string id="GregorianFormatMonthDayYear">Sep 17, 2025</string>
+
 
 </strings>

--- a/source/JF-HebrewCalendarView.mc
+++ b/source/JF-HebrewCalendarView.mc
@@ -289,7 +289,7 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     if (showGregorianDate) {
       bottomDateLabel.setColor(gregorianDateColor);
       bottomDateLabel.setText(gDate);
-      bottomDateLabel.setFont(frankFont);
+      //bottomDateLabel.setFont(frankFont);
     } else {
       bottomDateLabel.setText("");
     }
@@ -319,7 +319,7 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     var weekDay = info.day_of_week;
 
     var dayStr = day.format("%d");
-    var monthStr = month.format("%d");
+    var monthStr = month;//.format("%d");
     var yearStr = year.format("%d");
 
     var weekdayNames = [
@@ -346,26 +346,26 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
       "Dec",
     ];
 
-    var weekdayIndex = weekDay;
-    if (weekdayIndex < 1 || weekdayIndex > weekdayNames.size()) {
-      weekdayIndex = 1;
-    }
-    var monthIndex = month;
-    if (monthIndex < 1 || monthIndex > monthNames.size()) {
-      monthIndex = 1;
-    }
+    // var weekdayIndex = weekDay;
+    // if (weekdayIndex < 1 || weekdayIndex > weekdayNames.size()) {
+    //   weekdayIndex = 1;
+    // }
+    // var monthIndex = month;
+    // if (monthIndex < 1 || monthIndex > monthNames.size()) {
+    //   monthIndex = 1;
+    // }
 
-    var weekdayName = weekdayNames[weekdayIndex - 1];
-    var monthName = monthNames[monthIndex - 1];
+    var weekdayName = weekDay;//weekdayNames[weekdayIndex - 1];
+    var monthName = monthStr;// monthNames[monthIndex - 1];
     var format = gregorianDateFormat;
     if (format == null) {
       format = 3;
     }
 
     if (format == 1 || format == "1") {
-      return Lang.format("$1$ $2$ $3$", [weekdayName, dayStr, monthName]);
+      return Lang.format("$1$, $2$ $3$", [weekdayName, dayStr, monthName]);
     } else if (format == 2 || format == "2") {
-      return Lang.format("$1$ $2$ $3$", [
+      return Lang.format("$1$, $2$ $3$", [
         weekdayName,
         monthName,
         getOrdinalDay(day),

--- a/source/JF-HebrewCalendarView.mc
+++ b/source/JF-HebrewCalendarView.mc
@@ -44,6 +44,7 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
   var showTime = true;
   var showSeconds = true;
   var showGregorianDate = true;
+  var gregorianDateFormat = 3;
   var showSteps = true;
   var showSunEvent = true;
   var shabbatMode = false;
@@ -86,6 +87,17 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     return val == null ? current : val;
   }
 
+  function loadNumberSetting(name, current) {
+    var val = null;
+    if (!hasOldApi) {
+      val = appProperties.getValue(name);
+    } else {
+      val = Application.getApp().getProperty(name);
+    }
+
+    return val == null ? current : val;
+  }
+
   function loadColorSetting(name) {
     //
     if (!hasOldApi) {
@@ -102,6 +114,10 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     showGregorianDate = loadBooleanSetting(
       "showGregorianDate",
       showGregorianDate
+    );
+    gregorianDateFormat = loadNumberSetting(
+      "gregorianDateFormat",
+      gregorianDateFormat
     );
     showSteps = loadBooleanSetting("showSteps", showSteps);
     showSunEvent = loadBooleanSetting("showSunEvent", showSunEvent);
@@ -277,6 +293,90 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     } else {
       bottomDateLabel.setText("");
     }
+  }
+
+  function getOrdinalDay(day) {
+    var mod100 = day % 100;
+    var suffix = "th";
+    if (mod100 < 11 || mod100 > 13) {
+      var mod10 = day % 10;
+      if (mod10 == 1) {
+        suffix = "st";
+      } else if (mod10 == 2) {
+        suffix = "nd";
+      } else if (mod10 == 3) {
+        suffix = "rd";
+      }
+    }
+    return Lang.format("$1$$2$", [day.format("%d"), suffix]);
+  }
+
+  function formatGregorianDate(now) {
+    var info = Time.Gregorian.info(now, Time.FORMAT_LONG);
+    var day = info.day;
+    var month = info.month;
+    var year = info.year;
+    var weekDay = info.day_of_week;
+
+    var dayStr = day.format("%d");
+    var monthStr = month.format("%d");
+    var yearStr = year.format("%d");
+
+    var weekdayNames = [
+      "Sun",
+      "Mon",
+      "Tue",
+      "Wed",
+      "Thu",
+      "Fri",
+      "Sat",
+    ];
+    var monthNames = [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ];
+
+    var weekdayIndex = weekDay;
+    if (weekdayIndex < 1 || weekdayIndex > weekdayNames.size()) {
+      weekdayIndex = 1;
+    }
+    var monthIndex = month;
+    if (monthIndex < 1 || monthIndex > monthNames.size()) {
+      monthIndex = 1;
+    }
+
+    var weekdayName = weekdayNames[weekdayIndex - 1];
+    var monthName = monthNames[monthIndex - 1];
+    var format = gregorianDateFormat;
+    if (format == null) {
+      format = 3;
+    }
+
+    if (format == 1 || format == "1") {
+      return Lang.format("$1$ $2$ $3$", [weekdayName, dayStr, monthName]);
+    } else if (format == 2 || format == "2") {
+      return Lang.format("$1$ $2$ $3$", [
+        weekdayName,
+        monthName,
+        getOrdinalDay(day),
+      ]);
+    } else if (format == 3 || format == "3") {
+      return Lang.format("$1$/$2$/$3$", [dayStr, monthStr, yearStr]);
+    } else if (format == 4 || format == "4") {
+      return Lang.format("$1$ $2$, $3$", [monthName, dayStr, yearStr]);
+    }
+
+    return Lang.format("$1$/$2$/$3$", [dayStr, monthStr, yearStr]);
   }
 
   function updateSteps(dc as Dc, stepsNum) {
@@ -524,12 +624,7 @@ class JF_HebrewCalendarView extends WatchUi.WatchFace {
     var now = Time.now();
 
     var clockTime = System.getClockTime();
-    var gInfo = Time.Gregorian.info(now, Time.FORMAT_SHORT);
-    var gDate = Lang.format("$1$/$2$/$3$", [
-      gInfo.day.format("%02d"),
-      gInfo.month.format("%02d"),
-      gInfo.year,
-    ]);
+    var gDate = formatGregorianDate(now);
     var actInfo = ActivityMonitor.getInfo();
     var stepsNum = actInfo != null ? actInfo.steps : 0;
     var sunInfo = calculateSunInfo();


### PR DESCRIPTION
## Summary
- add a new setting and strings to let the user choose a Gregorian date format
- implement multiple display formats, including weekday-based and numeric options, and apply the selection to the watch face

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68ca4e2e2730832b88c77e145a53961f