### PR TITLE
Adjust Hanukkah end date when Kislev is full (30 days)

### DIFF
--- a/source/HebrewCalendar.mc
+++ b/source/HebrewCalendar.mc
@@ -563,7 +563,9 @@ class HebrewCalendar {
         return "חנוכה";
       }
     } else if (standardMonth == 10) {
-      if (day <= 3) {
+      var kislevLength = daysInHebrewMonth(year, 3);
+      var lastHanukkahDayInTevet = kislevLength == 30 ? 2 : 3;
+      if (day <= lastHanukkahDayInTevet) {
         return "חנוכה";
       }
     } else if (standardMonth == 12) {


### PR DESCRIPTION
### Motivation
- Fix Hanukkah labeling so the last day falls on 2 Tevet when Kislev has 30 days, instead of always showing through 3 Tevet.

### Description
- Change holiday detection in `source/HebrewCalendar.mc` to compute Kislev length using `daysInHebrewMonth(year, 3)` and determine the last Hanukkah day in Tevet accordingly. 
- Replace the hardcoded `day <= 3` check for Tevet with a computed `lastHanukkahDayInTevet` value set to `2` when Kislev is 30 and `3` otherwise. 
- The function still returns the Hebrew string `"חנוכה"` for the determined date range.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f6c8e0e34832bba777e7621c5bffb)