### PR TITLE
Add Connect IQ SDK setup script and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 
 # NPM / misc (if present)
 node_modules/
+
+# Local SDK downloads/installations
+.local/

--- a/README.md
+++ b/README.md
@@ -164,11 +164,37 @@ Access the watch face settings through:
 - [Garmin Connect IQ SDK](https://developer.garmin.com/connect-iq/sdk/)
 - Visual Studio Code with Monkey C extension
 
+### Connect IQ SDK setup
+
+Garmin SDK binaries are not committed to this repository. Download the Connect IQ SDK from Garmin and keep the archive outside version control, then install it locally with:
+
+```bash
+CONNECTIQ_SDK_ARCHIVE=/path/to/connectiq-sdk.zip scripts/setup-connectiq-sdk.sh
+```
+
+`CONNECTIQ_SDK_ARCHIVE` can also be an `https://` URL if your environment has access to a permitted SDK download location. The script unpacks the SDK into `.local/connectiq-sdk` by default and prints the detected SDK version. To install somewhere else, set `CONNECTIQ_SDK_INSTALL_DIR`.
+
+After installation, configure your shell or CI environment with one of these variables:
+
+```bash
+export CONNECTIQ_HOME="$PWD/.local/connectiq-sdk"
+# or, for tools that expect the alternate name:
+export CIQ_HOME="$CONNECTIQ_HOME"
+```
+
+Expected SDK tool paths:
+
+- Compiler: `$CONNECTIQ_HOME/bin/monkeyc`
+- Simulator runner, if used: `$CONNECTIQ_HOME/bin/monkeydo`
+
+Do not commit Garmin SDK archives or unpacked SDK binaries unless the Garmin license explicitly permits redistribution.
+
 ### Building
 1. Clone this repository
-2. Open in VS Code
-3. Use "Monkey C: Build" command
-4. Deploy to device or simulator
+2. Install the Garmin Connect IQ SDK and set `CONNECTIQ_HOME` or `CIQ_HOME`
+3. Open in VS Code
+4. Use "Monkey C: Build" command
+5. Deploy to device or simulator
 
 ### Project Structure
 ```

--- a/scripts/setup-connectiq-sdk.sh
+++ b/scripts/setup-connectiq-sdk.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARCHIVE_SOURCE="${CONNECTIQ_SDK_ARCHIVE:-}"
+INSTALL_DIR="${CONNECTIQ_SDK_INSTALL_DIR:-$ROOT_DIR/.local/connectiq-sdk}"
+DOWNLOAD_DIR="$ROOT_DIR/.local/downloads"
+
+usage() {
+  cat <<USAGE
+Usage:
+  CONNECTIQ_SDK_ARCHIVE=/path/to/connectiq-sdk.zip scripts/setup-connectiq-sdk.sh
+  CONNECTIQ_SDK_ARCHIVE=https://example.com/connectiq-sdk.zip scripts/setup-connectiq-sdk.sh
+
+Environment:
+  CONNECTIQ_SDK_ARCHIVE      Required. Local SDK archive path or URL.
+  CONNECTIQ_SDK_INSTALL_DIR  Optional. Install directory (default: .local/connectiq-sdk).
+
+The Garmin Connect IQ SDK license may restrict redistribution. This script does not
+vendor SDK binaries; it only unpacks the archive you provide.
+USAGE
+}
+
+if [[ -z "$ARCHIVE_SOURCE" ]]; then
+  usage >&2
+  exit 64
+fi
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+archive_name="$(basename "${ARCHIVE_SOURCE%%\?*}")"
+if [[ -z "$archive_name" || "$archive_name" == "." || "$archive_name" == "/" ]]; then
+  archive_name="connectiq-sdk-archive"
+fi
+
+mkdir -p "$DOWNLOAD_DIR"
+
+if [[ "$ARCHIVE_SOURCE" =~ ^https?:// ]]; then
+  archive_path="$DOWNLOAD_DIR/$archive_name"
+  if command_exists curl; then
+    curl --fail --location --show-error --output "$archive_path" "$ARCHIVE_SOURCE"
+  elif command_exists wget; then
+    wget --output-document="$archive_path" "$ARCHIVE_SOURCE"
+  else
+    echo "Error: downloading URLs requires curl or wget." >&2
+    exit 69
+  fi
+else
+  archive_path="$ARCHIVE_SOURCE"
+  if [[ ! -f "$archive_path" ]]; then
+    echo "Error: CONNECTIQ_SDK_ARCHIVE does not point to a file: $archive_path" >&2
+    exit 66
+  fi
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+case "$archive_path" in
+  *.zip)
+    if ! command_exists unzip; then
+      echo "Error: unzip is required to extract $archive_path." >&2
+      exit 69
+    fi
+    unzip -q "$archive_path" -d "$tmp_dir"
+    ;;
+  *.tar|*.tar.gz|*.tgz|*.tar.bz2|*.tbz2|*.tar.xz|*.txz)
+    tar -xf "$archive_path" -C "$tmp_dir"
+    ;;
+  *)
+    echo "Error: unsupported SDK archive format: $archive_path" >&2
+    echo "Supported formats: .zip, .tar, .tar.gz, .tgz, .tar.bz2, .tbz2, .tar.xz, .txz" >&2
+    exit 65
+    ;;
+esac
+
+sdk_root=""
+while IFS= read -r -d '' candidate; do
+  sdk_root="$(dirname "$(dirname "$candidate")")"
+  break
+done < <(find "$tmp_dir" -type f \( -name monkeyc -o -name monkeyc.exe \) -path '*/bin/*' -print0)
+
+if [[ -z "$sdk_root" ]]; then
+  echo "Error: could not find bin/monkeyc in the extracted SDK archive." >&2
+  exit 65
+fi
+
+rm -rf "$INSTALL_DIR"
+mkdir -p "$(dirname "$INSTALL_DIR")"
+cp -R "$sdk_root" "$INSTALL_DIR"
+
+compiler="$INSTALL_DIR/bin/monkeyc"
+runner="$INSTALL_DIR/bin/monkeydo"
+if [[ -e "${compiler}.exe" && ! -e "$compiler" ]]; then
+  compiler="${compiler}.exe"
+fi
+if [[ -e "${runner}.exe" && ! -e "$runner" ]]; then
+  runner="${runner}.exe"
+fi
+
+if [[ ! -x "$compiler" ]]; then
+  chmod +x "$compiler" 2>/dev/null || true
+fi
+if [[ -e "$runner" && ! -x "$runner" ]]; then
+  chmod +x "$runner" 2>/dev/null || true
+fi
+
+version="unknown"
+for version_file in \
+  "$INSTALL_DIR/sdk.version" \
+  "$INSTALL_DIR/VERSION" \
+  "$INSTALL_DIR/version.txt" \
+  "$INSTALL_DIR/manifest.xml"; do
+  if [[ -f "$version_file" ]]; then
+    version_line="$(sed -n '1,20p' "$version_file" | tr -d '\r' | grep -Eo '[0-9]+(\.[0-9]+)+' | head -1 || true)"
+    if [[ -n "$version_line" ]]; then
+      version="$version_line"
+      break
+    fi
+  fi
+done
+
+if [[ "$version" == "unknown" && -x "$compiler" ]]; then
+  version_line="$($compiler --version 2>&1 | grep -Eo '[0-9]+(\.[0-9]+)+' | head -1 || true)"
+  if [[ -n "$version_line" ]]; then
+    version="$version_line"
+  fi
+fi
+
+cat <<SUMMARY
+Connect IQ SDK installed.
+Version: $version
+CONNECTIQ_HOME=$INSTALL_DIR
+CIQ_HOME=$INSTALL_DIR
+Compiler: $compiler
+Simulator runner: $runner
+SUMMARY


### PR DESCRIPTION
### Motivation
- Provide a reproducible, non-vendoring way to install the Garmin Connect IQ SDK for local development and CI without committing SDK binaries.
- Make it easy to configure environment variables and document expected tool locations for the Monkey C toolchain.
- Ensure local SDK downloads/installs are ignored to avoid accidental commits of SDK artifacts.

### Description
- Add `scripts/setup-connectiq-sdk.sh`, which expects `CONNECTIQ_SDK_ARCHIVE` (local path or `https://` URL), extracts supported archive formats, locates `bin/monkeyc` to discover the SDK root, installs it to `.local/connectiq-sdk` by default or to `CONNECTIQ_SDK_INSTALL_DIR`, sets executable bits when needed, and prints a summary including detected version and paths (`CONNECTIQ_HOME`/`CIQ_HOME`, `bin/monkeyc`, `bin/monkeydo`).
- Detect SDK version from common files (`sdk.version`, `VERSION`, `version.txt`, `manifest.xml`) or by querying `monkeyc --version` when available, and handle Windows executables (`*.exe`) when present.
- Update `README.md` with `CONNECTIQ_SDK_ARCHIVE` install example and document the required environment variables `CONNECTIQ_HOME` / `CIQ_HOME` and expected tool paths (`$CONNECTIQ_HOME/bin/monkeyc`, `$CONNECTIQ_HOME/bin/monkeydo`).
- Update `.gitignore` to ignore `.local/` so local SDK downloads/installations are not committed.

### Testing
- Performed a shell syntax check with `bash -n scripts/setup-connectiq-sdk.sh`, which passed.
- Created a fake SDK zip containing `connectiq-sdk/bin/monkeyc`, `connectiq-sdk/bin/monkeydo`, and `connectiq-sdk/sdk.version` and ran `CONNECTIQ_SDK_ARCHIVE=<fake zip> CONNECTIQ_SDK_INSTALL_DIR=<tmp dir> scripts/setup-connectiq-sdk.sh`, and the script successfully installed the SDK into the target dir and printed the detected version and paths (expected output shown during test).
- Re-ran the installer after minor fixes (executable/`.exe` handling and version parsing) and verified the script still reports the correct version and tool paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bb5fcbb28832b9a718cff42fcfc4a)