### PR TITLE
Add command-line Connect IQ build script, README docs, and ignore build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ builds/
 out/
 dist/
 compiled/
+build/
 
 # Ignore packaged / device files
 *.prg

--- a/README.md
+++ b/README.md
@@ -165,10 +165,24 @@ Access the watch face settings through:
 - Visual Studio Code with Monkey C extension
 
 ### Building
+
+You can build from Visual Studio Code with the Monkey C extension:
+
 1. Clone this repository
 2. Open in VS Code
-3. Use "Monkey C: Build" command
+3. Use the "Monkey C: Build" command
 4. Deploy to device or simulator
+
+You can also build from the command line with `scripts/build.sh`. Set `CONNECTIQ_HOME` to your Garmin Connect IQ SDK path (or set `CIQ_HOME` as a fallback), set `GARMIN_DEVELOPER_KEY` to your developer key, and optionally set `GARMIN_DEVICE`. If `GARMIN_DEVICE` is omitted, the build script defaults to `fenix7`, which is listed in `manifest.xml`.
+
+```bash
+CONNECTIQ_HOME=/opt/connectiq \
+GARMIN_DEVELOPER_KEY=/path/to/developer_key.der \
+GARMIN_DEVICE=fenix7 \
+./scripts/build.sh
+```
+
+The script writes the compiled program to `build/JF-HebrewCalendar.prg`.
 
 ### Project Structure
 ```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,42 +5,32 @@ DEFAULT_GARMIN_DEVICE="fenix7"
 OUTPUT_DIR="build"
 OUTPUT_FILE="${OUTPUT_DIR}/JF-HebrewCalendar.prg"
 
-if [[ -z "${CONNECTIQ_HOME:-}" ]]; then
-  if [[ -n "${CIQ_HOME:-}" ]]; then
-    CONNECTIQ_HOME="${CIQ_HOME}"
-  else
-    cat >&2 <<'MSG'
-Error: CONNECTIQ_HOME is not set.
-Set CONNECTIQ_HOME to your Garmin Connect IQ SDK path, or set CIQ_HOME as a fallback.
-MSG
-    exit 1
-  fi
+fail() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+if [[ -z "${CONNECTIQ_HOME:-}" && -z "${CIQ_HOME:-}" ]]; then
+  fail "CONNECTIQ_HOME or CIQ_HOME must be set to your Garmin Connect IQ SDK path."
 fi
 
+CONNECTIQ_HOME="${CONNECTIQ_HOME:-${CIQ_HOME}}"
 MONKEYC="${CONNECTIQ_HOME}/bin/monkeyc"
+
+if [[ ! -e "${MONKEYC}" ]]; then
+  fail "monkeyc was not found at ${MONKEYC}. Check your CONNECTIQ_HOME/CIQ_HOME setting."
+fi
+
 if [[ ! -x "${MONKEYC}" ]]; then
-  cat >&2 <<MSG
-Error: monkeyc was not found or is not executable at:
-  ${MONKEYC}
-Check CONNECTIQ_HOME/CIQ_HOME and ensure the Connect IQ SDK is installed.
-MSG
-  exit 1
+  fail "monkeyc is not executable at ${MONKEYC}. Check the file permissions or SDK installation."
 fi
 
 if [[ -z "${GARMIN_DEVELOPER_KEY:-}" ]]; then
-  cat >&2 <<'MSG'
-Error: GARMIN_DEVELOPER_KEY is not set.
-Set GARMIN_DEVELOPER_KEY to the path of your Garmin developer key (.der) file.
-MSG
-  exit 1
+  fail "GARMIN_DEVELOPER_KEY must be set to the path of your Garmin developer key (.der) file."
 fi
 
 if [[ ! -f "${GARMIN_DEVELOPER_KEY}" ]]; then
-  cat >&2 <<MSG
-Error: GARMIN_DEVELOPER_KEY does not point to an existing file:
-  ${GARMIN_DEVELOPER_KEY}
-MSG
-  exit 1
+  fail "GARMIN_DEVELOPER_KEY does not point to an existing file: ${GARMIN_DEVELOPER_KEY}"
 fi
 
 GARMIN_DEVICE="${GARMIN_DEVICE:-${DEFAULT_GARMIN_DEVICE}}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_GARMIN_DEVICE="fenix7"
+OUTPUT_DIR="build"
+OUTPUT_FILE="${OUTPUT_DIR}/JF-HebrewCalendar.prg"
+
+if [[ -z "${CONNECTIQ_HOME:-}" ]]; then
+  if [[ -n "${CIQ_HOME:-}" ]]; then
+    CONNECTIQ_HOME="${CIQ_HOME}"
+  else
+    cat >&2 <<'MSG'
+Error: CONNECTIQ_HOME is not set.
+Set CONNECTIQ_HOME to your Garmin Connect IQ SDK path, or set CIQ_HOME as a fallback.
+MSG
+    exit 1
+  fi
+fi
+
+MONKEYC="${CONNECTIQ_HOME}/bin/monkeyc"
+if [[ ! -x "${MONKEYC}" ]]; then
+  cat >&2 <<MSG
+Error: monkeyc was not found or is not executable at:
+  ${MONKEYC}
+Check CONNECTIQ_HOME/CIQ_HOME and ensure the Connect IQ SDK is installed.
+MSG
+  exit 1
+fi
+
+if [[ -z "${GARMIN_DEVELOPER_KEY:-}" ]]; then
+  cat >&2 <<'MSG'
+Error: GARMIN_DEVELOPER_KEY is not set.
+Set GARMIN_DEVELOPER_KEY to the path of your Garmin developer key (.der) file.
+MSG
+  exit 1
+fi
+
+if [[ ! -f "${GARMIN_DEVELOPER_KEY}" ]]; then
+  cat >&2 <<MSG
+Error: GARMIN_DEVELOPER_KEY does not point to an existing file:
+  ${GARMIN_DEVELOPER_KEY}
+MSG
+  exit 1
+fi
+
+GARMIN_DEVICE="${GARMIN_DEVICE:-${DEFAULT_GARMIN_DEVICE}}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+"${MONKEYC}" \
+  -f monkey.jungle \
+  -o "${OUTPUT_FILE}" \
+  -y "${GARMIN_DEVELOPER_KEY}" \
+  -d "${GARMIN_DEVICE}"


### PR DESCRIPTION
### Motivation
- Provide a simple, reproducible command-line build path using the Garmin Connect IQ SDK so contributors can build without VS Code GUI steps.
- Fail early with clear messages when required environment or files are missing to reduce developer friction.
- Record the CLI usage and default device target in project docs and avoid committing generated build outputs.

### Description
- Add `scripts/build.sh`, an executable build helper that checks `CONNECTIQ_HOME` (falling back to `CIQ_HOME`), verifies `${CONNECTIQ_HOME}/bin/monkeyc` is executable, requires `GARMIN_DEVELOPER_KEY` and that it points to a file, defaults `GARMIN_DEVICE` to `fenix7`, creates the `build/` directory, and runs `monkeyc -f monkey.jungle -o build/JF-HebrewCalendar.prg -y "$GARMIN_DEVELOPER_KEY" -d "$GARMIN_DEVICE"`.
- Document command-line usage and the `fenix7` default in the `### Building` section of `README.md` with a copy-paste example using `CONNECTIQ_HOME`, `GARMIN_DEVELOPER_KEY`, and `GARMIN_DEVICE`.
- Add `build/` to `.gitignore` so generated outputs are not committed.
- Confirm `fenix7` is listed in `manifest.xml` and used as the documented default target.

### Testing
- Ran `bash -n scripts/build.sh` to validate script syntax, which succeeded.
- Executed `./scripts/build.sh` with no SDK env to verify the script fails clearly, which returned the expected error about `CONNECTIQ_HOME` being unset.
- Verified end-to-end invocation by stubbing a `monkeyc` binary and running `CONNECTIQ_HOME=<stub> GARMIN_DEVELOPER_KEY=<temp key> ./scripts/build.sh`, which succeeded and recorded the `monkeyc` arguments (`-f monkey.jungle -o build/JF-HebrewCalendar.prg -y <key> -d fenix7`) and created the `build/` directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bbaaf6470832ba06f59c78f783792)